### PR TITLE
Make scheduled_for table column not nullable and add current datetime as default

### DIFF
--- a/src/Migrations/PostMigration.php
+++ b/src/Migrations/PostMigration.php
@@ -20,7 +20,7 @@ class PostMigration
             $table->text('body');
             $table->boolean('published')->default(false);
             $table->boolean('featured')->default(false);
-            $table->datetime('scheduled_for')->nullable();
+            $table->datetime('scheduled_for')->useCurrent();
             $table->softDeletes();
             $table->timestamps();
         });


### PR DESCRIPTION
Because `scheduled_for` is nullable it makes it impossible to sort posts by date. This will help with that.